### PR TITLE
Conditional logic for rendering django messages via message-box vs new modal

### DIFF
--- a/chipy_org/apps/contact/templates/contact/contact.html
+++ b/chipy_org/apps/contact/templates/contact/contact.html
@@ -19,9 +19,7 @@
                     </table>
                     <div class="text-center">
                         <input class="btn btn-primary" type="submit" value="Send Email">
-                        <!-- <input class="btn btn-primary" type="submit" value="Send Email" data-bs-toggle="modal" data-bs-target="#contact-modal"> -->
                     </div>
-                    <div id="contact-modal-show" style="display:none" data-bs-toggle="modal" data-bs-target="#contact-modal"></div>
                   </form>
                 </div>
               </div>
@@ -40,6 +38,8 @@
     
     {% if messages %}
       <!-- CONTACT MODAL STARTS-->
+      <div id="contact-modal-show" style="display:none" data-bs-toggle="modal" data-bs-target="#contact-modal"></div>
+      
       <div class="modal fade" id="contact-modal" tabindex="-1" aria-labelledby="contactModalLabel" aria-hidden="true">
         <div class="modal-dialog modal-dialog-centered">
             <div class="modal-content">

--- a/chipy_org/apps/contact/templates/contact/contact.html
+++ b/chipy_org/apps/contact/templates/contact/contact.html
@@ -21,7 +21,6 @@
                         <input class="btn btn-primary" type="submit" value="Send Email">
                         <!-- <input class="btn btn-primary" type="submit" value="Send Email" data-bs-toggle="modal" data-bs-target="#contact-modal"> -->
                     </div>
-                    <div id="contact-modal-show" style="display:none" data-bs-toggle="modal" data-bs-target="#contact-modal"></div>
                   </form>
                 </div>
               </div>
@@ -40,6 +39,8 @@
     
     {% if messages %}
       <!-- CONTACT MODAL STARTS-->
+      <div id="contact-modal-show" style="display:none" data-bs-toggle="modal" data-bs-target="#contact-modal"></div>
+      
       <div class="modal fade" id="contact-modal" tabindex="-1" aria-labelledby="contactModalLabel" aria-hidden="true">
         <div class="modal-dialog modal-dialog-centered">
             <div class="modal-content">

--- a/chipy_org/apps/contact/templates/contact/contact.html
+++ b/chipy_org/apps/contact/templates/contact/contact.html
@@ -19,7 +19,9 @@
                     </table>
                     <div class="text-center">
                         <input class="btn btn-primary" type="submit" value="Send Email">
+                        <!-- <input class="btn btn-primary" type="submit" value="Send Email" data-bs-toggle="modal" data-bs-target="#contact-modal"> -->
                     </div>
+                    <div id="contact-modal-show" style="display:none" data-bs-toggle="modal" data-bs-target="#contact-modal"></div>
                   </form>
                 </div>
               </div>
@@ -35,7 +37,35 @@
           </div>
         </div>
     </div>
+    
+    {% if messages %}
+      <!-- CONTACT MODAL STARTS-->
+      <div class="modal fade" id="contact-modal" tabindex="-1" aria-labelledby="contactModalLabel" aria-hidden="true">
+        <div class="modal-dialog modal-dialog-centered">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <img src="https://via.placeholder.com/150"></img>
+                    <h5 class="modal-title black-text" id="contactModalLabel">Thank You.</h5>
+                </div>
+                <div class="modal-body">
+                    {% include "_messages.html" %}
+                    <button type="button" class="btn btn-primary" data-bs-dismiss="modal" aria-label="Close">Return to site</button>
+                </div>
+            </div>
+        </div>
+      </div>
+      <!-- CONTACT MODAL ENDS-->
+
+      <script>
+        window.addEventListener('load', function () {
+          document.querySelector("#contact-modal-show").click();
+        });
+      </script>
+
+    {% endif %}
 {% endblock %}
+
+
 
 {% block extra-javascript %}
 <script src="https://www.google.com/recaptcha/api.js" async defer></script>

--- a/chipy_org/apps/contact/templates/contact/contact.html
+++ b/chipy_org/apps/contact/templates/contact/contact.html
@@ -49,19 +49,25 @@
                 </div>
                 <div class="modal-body">
                     {% include "_messages.html" %}
-                    <button type="button" class="btn btn-primary" data-bs-dismiss="modal" aria-label="Close">Return to site</button>
+                    <button
+                      type="button"
+                      class="btn btn-primary"
+                      data-bs-dismiss="modal"
+                      aria-label="Close"
+                      onclick="javascript:window.location='/'">
+                      Return to home
+                    </button>
                 </div>
             </div>
         </div>
       </div>
-      <!-- CONTACT MODAL ENDS-->
 
       <script>
         window.addEventListener('load', function () {
           document.querySelector("#contact-modal-show").click();
         });
       </script>
-
+      <!-- CONTACT MODAL ENDS-->
     {% endif %}
 {% endblock %}
 

--- a/chipy_org/apps/contact/views.py
+++ b/chipy_org/apps/contact/views.py
@@ -8,6 +8,7 @@ class ContactView(FormView):
     template_name = "contact/contact.html"
     form_class = ContactForm
     success_url = "/contact"
+    message_as_modal = True
 
     def form_valid(self, form):
         try:
@@ -17,3 +18,9 @@ class ContactView(FormView):
             messages.error(self.request, "Your message was NOT sent to Chipy's organizers")
 
         return super().form_valid(form)
+
+    def get_context_data(self, **kwargs):
+        """ Used to access message_as_modal in template as context """
+        context = super(ContactView, self).get_context_data(**kwargs)
+        context.update({'message_as_modal': self.message_as_modal})
+        return context

--- a/chipy_org/apps/contact/views.py
+++ b/chipy_org/apps/contact/views.py
@@ -7,7 +7,7 @@ from chipy_org.apps.contact.forms import ContactForm
 class ContactView(FormView):
     template_name = "contact/contact.html"
     form_class = ContactForm
-    success_url = "/"
+    success_url = "/contact"
 
     def form_valid(self, form):
         try:

--- a/chipy_org/templates/_messages.html
+++ b/chipy_org/templates/_messages.html
@@ -1,12 +1,19 @@
-{% for message in messages %}
-    <div>{{ message|linebreaks }}</div>
-{% endfor %}
+{% if message_as_modal %}
+    {% for message in messages %}
+        <div>{{ message|linebreaks }}</div>
+    {% endfor %}
 
-<!-- ORIGINAL
-{% for message in messages %}
-    <div class="alert alert-dismissible {% if message.tags %} {% for tag in message.tags.split %}alert-{{ tag }} {% endfor %}{% endif %} fade show">
-        <a class="close" href="#" data-bs-dismiss="alert" aria-label="Close">&times;</a>
-        {{ message|linebreaks }}
-    </div>
-{% endfor %}
--->
+{% else %}
+    {% for message in messages %}
+    <div class="container-xl">
+        <div class="row">
+            <div class="col-md-12">
+                <div class="alert alert-dismissible {% if message.tags %} {% for tag in message.tags.split %}alert-{{ tag }} {% endfor %}{% endif %} fade show">
+                    <a class="close" href="#" data-bs-dismiss="alert" aria-label="Close">&times;</a>
+                    {{ message|linebreaks }}
+                </div>
+            </div>
+        </div>
+    </div><!--closes container xl-->
+    {% endfor %}
+{% endif %}

--- a/chipy_org/templates/_messages.html
+++ b/chipy_org/templates/_messages.html
@@ -1,6 +1,12 @@
 {% for message in messages %}
+    <div>{{ message|linebreaks }}</div>
+{% endfor %}
+
+<!-- ORIGINAL
+{% for message in messages %}
     <div class="alert alert-dismissible {% if message.tags %} {% for tag in message.tags.split %}alert-{{ tag }} {% endfor %}{% endif %} fade show">
         <a class="close" href="#" data-bs-dismiss="alert" aria-label="Close">&times;</a>
         {{ message|linebreaks }}
     </div>
 {% endfor %}
+-->

--- a/chipy_org/templates/shiny/slim.html
+++ b/chipy_org/templates/shiny/slim.html
@@ -17,14 +17,9 @@
 
 {% block content %}
 
-{% if messages %}
-<div class="container-xl">
-    <div class="row">
-        <div class="col-md-12">
-            {% include "_messages.html" %}
-        </div>
-    </div>
-</div><!--closes container xl-->
+<!-- Renders message box unless View declares message_as_modal instead -->
+{% if messages and not message_as_modal %}
+    {% include "_messages.html" %}
 {% endif %}
 
 <div class="container-xl">

--- a/chipy_org/templates/shiny/slim.html
+++ b/chipy_org/templates/shiny/slim.html
@@ -17,6 +17,7 @@
 
 {% block content %}
 
+<!-- ORIGINAL
 {% if messages %}
 <div class="container-xl">
     <div class="row">
@@ -24,8 +25,9 @@
             {% include "_messages.html" %}
         </div>
     </div>
-</div><!--closes container xl-->
+</div> --><!--closes container xl--><!--
 {% endif %}
+-->
 
 <div class="container-xl">
     <div class="row">

--- a/chipy_org/templates/shiny/slim.html
+++ b/chipy_org/templates/shiny/slim.html
@@ -17,7 +17,6 @@
 
 {% block content %}
 
-<!-- ORIGINAL
 {% if messages %}
 <div class="container-xl">
     <div class="row">
@@ -25,9 +24,8 @@
             {% include "_messages.html" %}
         </div>
     </div>
-</div> --><!--closes container xl--><!--
+</div><!--closes container xl-->
 {% endif %}
--->
 
 <div class="container-xl">
     <div class="row">


### PR DESCRIPTION
This branch represents an improved version of the current PR "Contact Form Feedback as Modal Issue#357" found [here](https://github.com/chicagopython/chipy.org/pull/422)

This branch **_does not break slim.html_** and will properly render the Contact form stuff as a modal, and everything else as a message-box.

---

# Per-File Changes (diffs vs main)

## contact/templates/contact/contact.html
Added HTML structure for modal. This is copied (and adapted classnames) from the existing modal implementation for the navbar's "Login" button. This HTML conditionally renders depending on whether or not there is a message to display.

The modal will {% include "_messages.html" %} in order to get the success/failure message.

The button to close the modal has an "onclick" function which takes the user to the Home page.

## contact/views.py
The ContactView itself now redirects to itself (/contact) for the purpose of displaying the modal. The modal button then redirects the user Home.

Added two things:
- a flag `message_as_modal = True` so that we can tell the template to render the message as a modal
- the django method `get_context_data`, which is what we use to communicate variables from the View over to the template. Here I've just added the `message_as_modal` value to the context dictionary.

## chipy_org/templates/_messages.html
Added an if-statement. If message_as_modal is True, then return the message that the modal wants. Otherwise, do what it was already doing (render the message-box exactly how it was).

## chipy_org/templates/shiny/slim.html
I've reverted my change that initially broke the message-boxes!

Two (small) new changes:
- There were a few divs that were containers for the alert/message-box. Since they are used exclusively for this message-box, I put them alongside the message-box HTML in _messages.html.
    - (in my opinion,) this will make the code a bit more readable if the modal functionality is made reusable.
        - (I have another branch where I've made the modal functionality reusable)
- The message-box will only render if `message_as_modal` is NOT set to True.